### PR TITLE
Extended implementation of the GooglePlaces API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ var settings = GoogleApiSettings.Builder
                                             .WithLanguage("nl")
                                             .WithType(PlaceTypes.Address)
                                             .WithLogger(new ConsoleLogger())
-											.WithDetailLevel(DetailLevel.Basic)
-											.WithSessionToken("YOUR SESSION TOKEN")
+					    .WithDetailLevel(DetailLevel.Basic)
+					    .WithSessionToken("YOUR SESSION TOKEN")
                                             .WithOrigin("lat,lon")
-											.WithLocation("lat,lon")
-											.AddCountry("nl")
-											.Build();
+					    .WithLocation("lat,lon")
+					    .AddCountry("nl")
+					    .Build();
 ```
 
 2. Create a service:
@@ -50,10 +50,10 @@ Stream photoStream = await _api.GetPhotoAsync("CnRtAAAATLZNl354RwP_9UKbQ_5Psy40t
 									  .ConfigureAwait(false);
 ```
 You can choose out of four detail levels, each [billed](https://developers.google.com/places/web-service/usage-and-billing seperately by Google:
-a. DetailLevel.Basic
-b. DetailLevel.Contact (= Basic + Contact)
-c. DetailLevel.Atmosphere (= Basic + Atmosphere)
-d. DetailLevel.Full (= Basic + Contact + Atmosphere)
+a. DetailLevel.Basic  
+b. DetailLevel.Contact (= Basic + Contact)  
+c. DetailLevel.Atmosphere (= Basic + Atmosphere)  
+d. DetailLevel.Full (= Basic + Contact + Atmosphere)  
 
 # Privacy Policy & Terms
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ var details = await service.GetDetailsAsync("ChIJOwg_06VPwokRYv534QaPC8g", GetSe
 Stream photoStream = await _api.GetPhotoAsync("CnRtAAAATLZNl354RwP_9UKbQ_5Psy40texXePv4oAlgP4qNEkdIrkyse7rPXYGd9D_Uj1rVsQdWT4oRz4QrYAJNpFX7rzqqMlZw2h2E2y5IKMUZ7ouD_SlcHxYq1yL4KbKUv3qtWgTK0A6QbGh87GB3sscrHRIQiG2RrmU_jF4tENr9wGS_YxoUSSDrYjWmrNfeEHSGSc3FyhNLlBU")
 									  .ConfigureAwait(false);
 ```
-You can choose out of four detail levels, each [billed](https://developers.google.com/places/web-service/usage-and-billing seperately by Google:
+You can choose out of four detail levels, each [billed](https://developers.google.com/places/web-service/usage-and-billing) seperately by Google:  
 a. DetailLevel.Basic  
 b. DetailLevel.Contact (= Basic + Contact)  
 c. DetailLevel.Atmosphere (= Basic + Atmosphere)  
@@ -57,4 +57,4 @@ d. DetailLevel.Full (= Basic + Contact + Atmosphere)
 
 # Privacy Policy & Terms
 
-Please read the [Google Privact & Terms](https://policies.google.com/terms?hl=en) and [Privacy Policy](https://policies.google.com/privacy) when you want to use this plugin!
+Please read the [Google Privacy & Terms](https://policies.google.com/terms?hl=en) and [Privacy Policy](https://policies.google.com/privacy) when you want to use this plugin!

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # GooglePlacesApi
 
-This plugin makes it very easy to use the Google Places API. Please read my [blog](https://blog.duijzer.com/posts/google-places-api/) for the nitty-gritty details.
+This plugin makes it very easy to use the Google Places API. Please read Jacob Duijzer's [blog](https://blog.duijzer.com/posts/google-places-api/) for the nitty-gritty details.
 
 # Usage
 
@@ -17,8 +17,12 @@ var settings = GoogleApiSettings.Builder
                                             .WithLanguage("nl")
                                             .WithType(PlaceTypes.Address)
                                             .WithLogger(new ConsoleLogger())
-                                            .AddCountry("nl")
-                                            .Build();
+											.WithDetailLevel(DetailLevel.Basic)
+											.WithSessionToken("YOUR SESSION TOKEN")
+                                            .WithOrigin("lat,lon")
+											.WithLocation("lat,lon")
+											.AddCountry("nl")
+											.Build();
 ```
 
 2. Create a service:
@@ -33,12 +37,23 @@ var service = new GooglePlacesApiService(settings);
 var result = await service.GetPredictionsAsync("new y").ConfigureAwait(false);
 ```
 
-4. Get details:
+4. Get details (you can also add a new session token in argument 2, if argument 3 is not given DetailLevel.Basic is used):
 
 ```
-var details = await service.GetDetailsAsync("ChIJOwg_06VPwokRYv534QaPC8g")
+var details = await service.GetDetailsAsync("ChIJOwg_06VPwokRYv534QaPC8g", GetSessionToken(), DetailLevel.Full)
                                       .ConfigureAwait(false);
 ```
+5. Get photos:
+
+```
+Stream photoStream = await _api.GetPhotoAsync("CnRtAAAATLZNl354RwP_9UKbQ_5Psy40texXePv4oAlgP4qNEkdIrkyse7rPXYGd9D_Uj1rVsQdWT4oRz4QrYAJNpFX7rzqqMlZw2h2E2y5IKMUZ7ouD_SlcHxYq1yL4KbKUv3qtWgTK0A6QbGh87GB3sscrHRIQiG2RrmU_jF4tENr9wGS_YxoUSSDrYjWmrNfeEHSGSc3FyhNLlBU")
+									  .ConfigureAwait(false);
+```
+You can choose out of four detail levels, each [billed](https://developers.google.com/places/web-service/usage-and-billing seperately by Google:
+a. DetailLevel.Basic
+b. DetailLevel.Contact (= Basic + Contact)
+c. DetailLevel.Atmosphere (= Basic + Atmosphere)
+d. DetailLevel.Full (= Basic + Contact + Atmosphere)
 
 # Privacy Policy & Terms
 

--- a/src/GooglePlacesApi.Abstractions/Interfaces/IGooglePlacesApi.cs
+++ b/src/GooglePlacesApi.Abstractions/Interfaces/IGooglePlacesApi.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.IO;
+using System.Threading.Tasks;
 using GooglePlacesApi.Models;
 using Refit;
 
@@ -9,7 +10,10 @@ namespace GooglePlacesApi.Interfaces
         [Get("/maps/api/place/autocomplete/json?input={input}")]
         Task<Predictions> GetAutocompleteAsync(string input, GoogleApiQueryStringParameters queryStringParameters);
 
-        [Get("/maps/api/place/details/json?key={apiKey}&placeid={placeId}")]
-        Task<Details> GetDetailsAsync(string apiKey, string placeId);
+        [Get("/maps/api/place/details/json?key={apiKey}&placeid={placeId}&fields={fields}")]
+        Task<Details> GetDetailsAsync(string apiKey, string placeId, string sessionToken, string fields);
+
+        [Get("/maps/api/place/photo?maxwidth=400&photoreference={photoReference}&key={apiKey}")]
+        Task<Stream> GetPhotoAsync(string apiKey, string photoReference);
     }
 }

--- a/src/GooglePlacesApi.Abstractions/Interfaces/IGooglePlacesApiService.cs
+++ b/src/GooglePlacesApi.Abstractions/Interfaces/IGooglePlacesApiService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.IO;
+using System.Threading.Tasks;
 using GooglePlacesApi.Models;
 
 namespace GooglePlacesApi.Interfaces
@@ -7,6 +8,12 @@ namespace GooglePlacesApi.Interfaces
     {
         Task<Predictions> GetPredictionsAsync(string searchText);
 
-        Task<Details> GetDetailsAsync(string placeId);
+        Task<Details> GetDetailsAsync(string placeId, string sessionToken, DetailLevel detailLevel = DetailLevel.Basic);
+
+        Task<Stream> GetPhotoAsync(string photoReference);
+
+        string GetSessionToken();
+
+        void ResetSessionToken();
     }
 }

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApi/DetailLevel.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApi/DetailLevel.cs
@@ -1,0 +1,10 @@
+﻿namespace GooglePlacesApi.Models
+{
+    public enum DetailLevel
+    {
+        Basic,
+        Contact,
+        Atmosphere, 
+        Full
+    }
+}

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApi/OpeningHours.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApi/OpeningHours.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace GooglePlacesApi.Models
+{
+    public class OpeningHours
+    {
+        [JsonProperty("open_now")]
+        public bool OpenNow { get; set; }
+
+        [JsonProperty("periods")]
+        public List<Period> Periods { get; set; }
+
+        [JsonProperty("weekday_text")]
+        public List<string> WeekdayText { get; set; }
+    }
+}

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApi/Period.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApi/Period.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace GooglePlacesApi.Models
+{
+    public class Period
+    {
+        
+        [JsonProperty("open")]
+        public PeriodDetail Open { get; set; }
+
+        [JsonProperty("close")]
+        public PeriodDetail Close { get; set; }
+    }
+}

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApi/Period.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApi/Period.cs
@@ -6,7 +6,6 @@ namespace GooglePlacesApi.Models
 {
     public class Period
     {
-        
         [JsonProperty("open")]
         public PeriodDetail Open { get; set; }
 

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApi/PeriodDetail.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApi/PeriodDetail.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace GooglePlacesApi.Models
+{
+    public class PeriodDetail
+    {
+        [JsonProperty("day")]
+        public int Day { get; set; }
+
+        [JsonProperty("time")]
+        public string Time { get; set; }
+    }
+}

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApi/Place.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApi/Place.cs
@@ -1,12 +1,15 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
 using Newtonsoft.Json;
 
 namespace GooglePlacesApi.Models
 {
     public class Place
     {
+        // Basic fields
+
         [JsonProperty("id")]
-        public string Id { get; set; }
+        public string Id { get; set; }  
 
         [JsonProperty("place_id")]
         public string PlaceId { get; set; }
@@ -19,7 +22,7 @@ namespace GooglePlacesApi.Models
 
         [JsonProperty("formatted_address")]
         public string FormattedAddress { get; set; }
-
+                
         [JsonProperty("reference")]
         public string Reference { get; set; }
 
@@ -35,13 +38,16 @@ namespace GooglePlacesApi.Models
         [JsonProperty("types")]
         public List<string> Types { get; set; }
 
-        [JsonProperty("Photos")]
+        [JsonProperty("photos")]
         public List<Photo> Photos { get; set; }
 
+        [JsonProperty("plus_code")]
+        public PlusCode Pluscode { get; set; }
+        
         [JsonProperty("scope")]
         public string Scope { get; set; }
 
-        [JsonProperty("ulr")]
+        [JsonProperty("url")]
         public string Url { get; set; }
 
         [JsonProperty("utc_offset")]
@@ -49,5 +55,36 @@ namespace GooglePlacesApi.Models
 
         [JsonProperty("vicinity")]
         public string Vicinity { get; set; }
+        
+        [JsonProperty("permanently_closed")]
+        public bool PermanentlyClosed { get; set; }
+
+        //Contact details (billed extra if requested)
+
+        [JsonProperty("international_phone_number")]
+        public string InternationalPhoneNumber { get; set; }
+
+        [JsonProperty("formatted_phone_number")]
+        public string FormattedPhoneNumber { get; set; }
+
+        [JsonProperty("opening_hours")]
+        public OpeningHours OpeningHours { get; set; }
+
+        [JsonProperty("website")]
+        public string Website { get; set; }
+
+        //Atmosphere details (billed extra if requested)
+
+        [JsonProperty("price_level")]
+        public int PriceLevel { get; set; }
+
+        [JsonProperty("rating")]
+        public double Rating { get; set; }
+
+        [JsonProperty("reviews")]
+        public List<Review> Reviews { get; set; }
+
+        [JsonProperty("user_ratings_total")]
+        public string UserRatingsTotal { get; set; }
     }
 }

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApi/PlusCode.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApi/PlusCode.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel;
+using Newtonsoft.Json;
+
+namespace GooglePlacesApi.Models
+{
+    public class PlusCode
+    {
+        
+        [JsonProperty("open")]
+        public string CompoundCode { get; set; }
+
+        [JsonProperty("close")]
+        public string GlobalCode { get; set; }
+    }
+}

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApi/PlusCode.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApi/PlusCode.cs
@@ -6,7 +6,6 @@ namespace GooglePlacesApi.Models
 {
     public class PlusCode
     {
-        
         [JsonProperty("open")]
         public string CompoundCode { get; set; }
 

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApi/Review.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApi/Review.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace GooglePlacesApi.Models
+{
+    public class Review
+    {
+        [JsonProperty("author_name")]
+        public string AuthorName { get; set; }
+
+        [JsonProperty("author_url")]
+        public string AuthorUrl { get; set; }
+
+        [JsonProperty("profile_photo_url")]
+        public string ProfilePhotoUrl { get; set; }
+
+        [JsonProperty("language")]
+        public string Language { get; set; }
+
+        [JsonProperty("rating")]
+        public int Rating { get; set; }
+
+        [JsonProperty("text")]
+        public string Text { get; set; }
+
+        [JsonProperty("time")]
+        public string Time { get; set; }
+    }
+}
+

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApi/Review.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApi/Review.cs
@@ -27,4 +27,3 @@ namespace GooglePlacesApi.Models
         public string Time { get; set; }
     }
 }
-

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApiQueryStringParameters.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApiQueryStringParameters.cs
@@ -34,6 +34,5 @@ namespace GooglePlacesApi.Models
 
         //[AliasAs("strictbounds")]
         public bool StrictBounds { get; set; }
-
     }
 }

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApiQueryStringParameters.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApiQueryStringParameters.cs
@@ -1,4 +1,5 @@
 ﻿using Refit;
+using System;
 
 namespace GooglePlacesApi.Models
 {
@@ -15,5 +16,24 @@ namespace GooglePlacesApi.Models
 
         [AliasAs("types")]
         public string PlaceType { get; set; }
+
+        [AliasAs("sessiontoken")]
+        public string SessionToken { get; set; }
+
+        //[AliasAs("offset")]
+        public int Offset { get; set; }
+
+        [AliasAs("origin")]
+        public string Origin { get; set; }
+
+        [AliasAs("location")]
+        public string Location { get; set; }
+
+        //[AliasAs("radius")]
+        public int Radius { get; set; }
+
+        //[AliasAs("strictbounds")]
+        public bool StrictBounds { get; set; }
+
     }
 }

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApiSettings.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApiSettings.cs
@@ -159,7 +159,6 @@ namespace GooglePlacesApi.Models
                     Location = _location,
                     Radius = _radius,
                     StrictBounds = _strictBounds
-
                 };
             }
         }

--- a/src/GooglePlacesApi.Abstractions/Models/GoogleApiSettings.cs
+++ b/src/GooglePlacesApi.Abstractions/Models/GoogleApiSettings.cs
@@ -17,6 +17,20 @@ namespace GooglePlacesApi.Models
 
         public IRefitLogger Logger { get; private set; }
 
+        public DetailLevel DetailLevel { get; private set; }
+
+        public string SessionToken { get; set; } 
+
+        public int Offset { get; private set; }
+
+        public string Origin { get; private set; }
+
+        public string Location { get; private set; }
+
+        public int Radius { get; private set; }
+
+        public bool StrictBounds { get; private set; } = false;
+
         private GoogleApiSettings()
         {
         }
@@ -29,7 +43,14 @@ namespace GooglePlacesApi.Models
         {
             private string _apiKey;
             private string _language;
+            private string _sessionToken;
+            private int _offset;
+            private string _origin;
+            private string _location;
+            private int _radius;
+            private bool _strictBounds;
             private PlaceTypes _type;
+            private DetailLevel _detailLevel;
             private readonly List<string> _countries = new List<string>();
             private IRefitLogger _logger;
 
@@ -56,7 +77,47 @@ namespace GooglePlacesApi.Models
                 _type = type;
                 return this;
             }
+            public SettingsBuilder WithDetailLevel(DetailLevel detailLevel)
+            {
+                _detailLevel = detailLevel;
+                return this;
+            }
 
+            public SettingsBuilder WithSessionToken(string sessionToken)
+            {
+                _sessionToken = sessionToken;
+                return this;
+            }
+
+            public SettingsBuilder WithOffset(int offset)
+            {
+                _offset = offset;
+                return this;
+            }
+
+            public SettingsBuilder WithOrigin(string origin)
+            {
+                _origin = origin;
+                return this;
+            }
+
+            public SettingsBuilder WithLocation(string location)
+            {
+                _location = location;
+                return this;
+            }
+
+            public SettingsBuilder WithRadius(int radius)
+            {
+                _radius = radius;
+                return this;
+            }
+
+            public SettingsBuilder WithStrictBounds(bool strictBounds)
+            {
+                _strictBounds = strictBounds;
+                return this;
+            }
 
             public SettingsBuilder AddCountry(string country)
             {
@@ -90,7 +151,15 @@ namespace GooglePlacesApi.Models
                     Language = _language,
                     PlaceType = _type,
                     Countries = _countries,
-                    Logger = _logger
+                    Logger = _logger,
+                    DetailLevel = _detailLevel,
+                    SessionToken = _sessionToken,
+                    Offset = _offset,
+                    Origin = _origin,
+                    Location = _location,
+                    Radius = _radius,
+                    StrictBounds = _strictBounds
+
                 };
             }
         }

--- a/src/GooglePlacesApi.Tests/IntegrationTests/GoogleApiServiceShould.cs
+++ b/src/GooglePlacesApi.Tests/IntegrationTests/GoogleApiServiceShould.cs
@@ -56,7 +56,7 @@ namespace GooglePlacesApi.Tests.IntegrationTests
             var predictions = await service.GetPredictionsAsync("new y")
                                            .ConfigureAwait(false);
 
-            var details = await service.GetDetailsAsync(predictions.Items.FirstOrDefault().PlaceId)
+            var details = await service.GetDetailsAsync(predictions.Items.FirstOrDefault().PlaceId, service.GetSessionToken())
                                        .ConfigureAwait(false);
 
             details.Should()

--- a/src/GooglePlacesApi.Tests/UnitTests/Service/GoogleApiServiceShould.cs
+++ b/src/GooglePlacesApi.Tests/UnitTests/Service/GoogleApiServiceShould.cs
@@ -48,7 +48,7 @@ namespace GooglePlacesApi.Tests.UnitTests.Service
         public void ThrowWhenPlaceIdIsNullOrEmpty(string input)
         {
             var service = new GooglePlacesApiService(GoogleApiSettings.Builder.WithApiKey("testkey").Build());
-            var action = new Func<Task>(async () => await service.GetDetailsAsync(input));
+            var action = new Func<Task>(async () => await service.GetDetailsAsync(input, service.GetSessionToken()));
             action.Should()
                   .Throw<ArgumentNullException>()
                   .WithMessage($"Value cannot be null.{Environment.NewLine}Parameter name: placeId");

--- a/src/GooglePlacesApi/Services/GooglePlacesApiService.cs
+++ b/src/GooglePlacesApi/Services/GooglePlacesApiService.cs
@@ -38,7 +38,7 @@ namespace GooglePlacesApi
             if (_settings.Logger != null)
                 refitSettings.HttpMessageHandlerFactory = () => new LoggingHandler(new HttpClientHandler(), _settings.Logger);
 
-            _api = RestService.For<IGooglePlacesApi>(Constants.BASE_API_URL, refitSettings); ;            
+            _api = RestService.For<IGooglePlacesApi>(Constants.BASE_API_URL, refitSettings);           
         }
         
         public async Task<Predictions> GetPredictionsAsync(string searchText)

--- a/src/GooglePlacesApi/Services/GooglePlacesApiService.cs
+++ b/src/GooglePlacesApi/Services/GooglePlacesApiService.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using GooglePlacesApi.Extensions;
 using GooglePlacesApi.Handlers;
 using GooglePlacesApi.Interfaces;
 using GooglePlacesApi.Models;
+using Newtonsoft.Json;
 using Refit;
 
 namespace GooglePlacesApi
@@ -20,18 +22,25 @@ namespace GooglePlacesApi
             if (settings == null)
                 throw new ArgumentNullException(nameof(settings));
 
-            if(string.IsNullOrEmpty(settings.ApiKey))
+            if (string.IsNullOrEmpty(settings.ApiKey))
                 throw new InvalidOperationException("ApiKey must be set");
 
+            if (string.IsNullOrEmpty(settings.SessionToken))
+                settings.SessionToken = Guid.NewGuid().ToString();
+
             _settings = settings;
+
+            JsonConvert.DefaultSettings =
+            () => new JsonSerializerSettings() { MissingMemberHandling = MissingMemberHandling.Ignore };
 
             var refitSettings = new RefitSettings();
 
             if (_settings.Logger != null)
                 refitSettings.HttpMessageHandlerFactory = () => new LoggingHandler(new HttpClientHandler(), _settings.Logger);
-            
-            _api = RestService.For<IGooglePlacesApi>(Constants.BASE_API_URL, refitSettings);
+
+            _api = RestService.For<IGooglePlacesApi>(Constants.BASE_API_URL, refitSettings); ;            
         }
+        
         public async Task<Predictions> GetPredictionsAsync(string searchText)
         {
             if (string.IsNullOrWhiteSpace(searchText))
@@ -41,14 +50,56 @@ namespace GooglePlacesApi
                                  .ConfigureAwait(false);
         }
 
-
-        public async Task<Details> GetDetailsAsync(string placeId)
+        public async Task<Details> GetDetailsAsync(string placeId, string sessionToken, DetailLevel detailLevel = DetailLevel.Basic)
         {
             if (string.IsNullOrWhiteSpace(placeId))
                 throw new ArgumentNullException(nameof(placeId));
 
-            return await _api.GetDetailsAsync(_settings.ApiKey, placeId)
+            string fields = null;
+
+            switch (detailLevel)
+            {
+                case DetailLevel.Basic:
+                    fields = "id,place_id,name,geometry,formatted_address,reference,icon,address_components,adr_address,types,photos,plus_code,scope,url,utc_offset,vicinity,permanently_closed";
+                    break;
+
+                case DetailLevel.Contact:
+                    fields = "id,place_id,name,geometry,formatted_address,reference,icon,address_components,adr_address,types,photos,plus_code,scope,url,utc_offset,vicinity,permanently_closed,formatted_phone_number,international_phone_number,opening_hours,website";
+                    break;
+
+                case DetailLevel.Atmosphere:
+                    fields = "id,place_id,name,geometry,formatted_address,reference,icon,address_components,adr_address,types,photos,plus_code,scope,url,utc_offset,vicinity,permanently_closed,price_level,rating,review,user_ratings_total";
+                    break;
+
+                case DetailLevel.Full:
+                    fields = "id,place_id,name,geometry,formatted_address,reference,icon,address_components,adr_address,types,photos,plus_code,scope,url,utc_offset,vicinity,permanently_closed,formatted_phone_number,international_phone_number,opening_hours,website,price_level,rating,review,user_ratings_total";
+                    break;
+            }
+
+            var result = await _api.GetDetailsAsync(_settings.ApiKey, placeId, sessionToken, fields)
                              .ConfigureAwait(false);
+            // as session has been fully used now, reset session: does not have effect when the details are retreived in different instance of the service: therefore you can also call for a reset in your forms project
+            ResetSessionToken();
+            return result;
+        }
+
+        public async Task<Stream> GetPhotoAsync(string photoReference)
+        {
+            if (string.IsNullOrWhiteSpace(photoReference))
+                throw new ArgumentNullException(nameof(photoReference));
+
+            Stream result = await _api.GetPhotoAsync(_settings.ApiKey, photoReference)
+                             .ConfigureAwait(false);
+
+            return result;
+        }
+        public string GetSessionToken()
+        {
+            return _settings.SessionToken;
+        }
+        public void ResetSessionToken()
+        {
+            _settings.SessionToken = Guid.NewGuid().ToString();
         }
     }
 }

--- a/src/samples/Xamarin.Forms/StoreLocator/ViewModels/SimpleFormDetailViewModel.cs
+++ b/src/samples/Xamarin.Forms/StoreLocator/ViewModels/SimpleFormDetailViewModel.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using GooglePlacesApi;
 using GooglePlacesApi.Models;
 using MvvmHelpers;
 using Nito.AsyncEx;
+using Xamarin.Forms;
 
 namespace StoreLocator.ViewModels
 {
@@ -13,18 +15,17 @@ namespace StoreLocator.ViewModels
 
         private readonly GooglePlacesApiService _api;
 
-        public SimpleFormDetailViewModel(string placeId)
+        public SimpleFormDetailViewModel(string placeId, string sessionToken)
         {
             _placeId = placeId;
 
-            var settings = GoogleApiSettings.Builder.WithApiKey(Environment.GetEnvironmentVariable("GOOGLE_PLACES_API_KEY")).Build();
+            var settings = GoogleApiSettings.Builder.WithApiKey(Environment.GetEnvironmentVariable("GOOGLE_PLACES_API_KEY")).WithSessionToken(sessionToken).Build();
 
             _api = new GooglePlacesApiService(settings);
 
-            TaskCompletion = NotifyTaskCompletion.Create(GetPlaceDetailsAsync);
+            Details = Task.Run(async () => await GetPlaceDetailsAsync()).Result;
+            Task.Run(() => GetPhotoAsync(Details.Place.Photos[0].PhotoReference));
         }
-
-        public INotifyTaskCompletion TaskCompletion;
 
         private Details _details;
         public Details Details
@@ -33,8 +34,24 @@ namespace StoreLocator.ViewModels
             set => SetProperty(ref _details, value);
         }
 
-        private async Task GetPlaceDetailsAsync()
-        => Details = await _api.GetDetailsAsync(_placeId)
+        private ImageSource _placePhoto;
+        public ImageSource PlacePhoto
+        {
+            get => _placePhoto;
+            set => SetProperty(ref _placePhoto, value);
+        }
+
+        private async Task<Details> GetPlaceDetailsAsync()
+        {
+            return await _api.GetDetailsAsync(_placeId, _api.GetSessionToken(), DetailLevel.Basic)
                                .ConfigureAwait(false);
+        }
+
+        private async Task GetPhotoAsync(string photoReference)
+        {
+            Stream photoStream = await _api.GetPhotoAsync(photoReference)
+                               .ConfigureAwait(false);
+            PlacePhoto = ImageSource.FromStream(() => photoStream);
+        }
     }
 }

--- a/src/samples/Xamarin.Forms/StoreLocator/ViewModels/SimpleFormViewModel.cs
+++ b/src/samples/Xamarin.Forms/StoreLocator/ViewModels/SimpleFormViewModel.cs
@@ -29,7 +29,11 @@ namespace StoreLocator.ViewModels
         => new Command(async () => await DoSearchAsync().ConfigureAwait(false), () => CanSearch);
 
         public ICommand SelectItemCommand
-        => new Command<Prediction>(async (prediction) => await _navigation.PushAsync(new SimpleFormDetailPage(prediction.PlaceId)).ConfigureAwait(false));
+        => new Command<Prediction>(async (prediction) =>
+        {
+            await _navigation.PushAsync(new SimpleFormDetailPage(prediction.PlaceId, _api.GetSessionToken())).ConfigureAwait(false);
+            _api.ResetSessionToken();
+        });
 
         private string _searchText;
         public string SearchText
@@ -64,6 +68,7 @@ namespace StoreLocator.ViewModels
             var results = await _api.GetPredictionsAsync(SearchText)
                                     .ConfigureAwait(false);
 
+            
             if(results != null && results.Status.Equals("OK"))
             {
                 ResultCount = results.Items.Count;

--- a/src/samples/Xamarin.Forms/StoreLocator/ViewModels/SimpleFormViewModel.cs
+++ b/src/samples/Xamarin.Forms/StoreLocator/ViewModels/SimpleFormViewModel.cs
@@ -67,8 +67,7 @@ namespace StoreLocator.ViewModels
         {
             var results = await _api.GetPredictionsAsync(SearchText)
                                     .ConfigureAwait(false);
-
-            
+                        
             if(results != null && results.Status.Equals("OK"))
             {
                 ResultCount = results.Items.Count;

--- a/src/samples/Xamarin.Forms/StoreLocator/Views/SimpleFormDetailPage.xaml
+++ b/src/samples/Xamarin.Forms/StoreLocator/Views/SimpleFormDetailPage.xaml
@@ -8,7 +8,9 @@
                      Margin="20, 40, 20, 20">
 
             <Image Source="{Binding Details.Place.Icon}"/>
-            
+
+            <Image Source="{Binding PlacePhoto}" />
+
             <Label Text="{Binding Details.Place.Name, StringFormat='Name: {0}'}"/>
             <Label Text="{Binding Details.Place.Geometry.Location.Latitude, StringFormat='Latitude: {0}'}"/>
             <Label Text="{Binding Details.Place.Geometry.Location.Longitude, StringFormat='Longitude: {0}'}"/>

--- a/src/samples/Xamarin.Forms/StoreLocator/Views/SimpleFormDetailPage.xaml.cs
+++ b/src/samples/Xamarin.Forms/StoreLocator/Views/SimpleFormDetailPage.xaml.cs
@@ -6,11 +6,11 @@ namespace StoreLocator.Views
 {
     public partial class SimpleFormDetailPage : ContentPage
     {
-        public SimpleFormDetailPage(string placeId)
+        public SimpleFormDetailPage(string placeId, string sessionToken)
         {
             InitializeComponent();
 
-            BindingContext = new SimpleFormDetailViewModel(placeId);
+            BindingContext = new SimpleFormDetailViewModel(placeId, sessionToken);
         }
     }
 }


### PR DESCRIPTION
Implementation of multiple detail levels: Basis, Contact, Atmosphere and Full, for cheaper requests. 
Implementation of a function to retrieve images. 
Implementation to use other parameters: sessiontoken, origin and location. 
Implementation to retrieve other fields of place: plus_code, url, permanently_closed, international_phone_number, formatted_phone_number, opening_hours, website, price_level, rating, reviews and user_ratings_total. 
Auto reset sessiontoken when DetailLevel is used (only if same instance is used). 

Possible improvements:
- Maybe implement a way to not use a SessionToken at all (now one is generated if null)
- Find a way to use the parameters 'offset' (null value turn to 0 and has effect on search behaviour), 
- 'radius' and 'strict_bounds' (these are normally only used in combination with 'location' or 'origin'.